### PR TITLE
feat(auth): register/token-json/me with bcrypt + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ Manual (no Docker):
   pip install -r backend\\requirements.txt
   pytest -q
   uvicorn app.main:app --host 0.0.0.0 --port 8001
+
+## Auth quickstart
+powershell:
+  $u = "http://localhost:8001"
+  Invoke-RestMethod -Uri "$u/auth/register" -Method Post -Body (@{username='alice';password='secret'} | ConvertTo-Json) -ContentType "application/json"
+  $tok = Invoke-RestMethod -Uri "$u/auth/token-json" -Method Post -Body (@{username='alice';password='secret'} | ConvertTo-Json) -ContentType "application/json"
+  Invoke-RestMethod -Uri "$u/auth/me" -Headers @{Authorization="Bearer $($tok.access_token)"}

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from app.routers.auth import router as auth_router
+
 app = FastAPI(title="app_v1")
 
 app.add_middleware(
@@ -10,6 +12,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+app.include_router(auth_router)
+
 
 @app.get("/healthz")
 def healthz():

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,0 +1,1 @@
+# routers package

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import secrets
+
+import bcrypt
+from fastapi import APIRouter, HTTPException, Header
+
+from app.schemas import UserIn, UserOut, TokenOut
+from app.storage import load_db, save_db
+
+router = APIRouter(prefix="/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=UserOut)
+def register(user_in: UserIn) -> UserOut:
+    db = load_db()
+    if any(u["username"] == user_in.username for u in db["users"]):
+        raise HTTPException(status_code=409, detail="nom d'utilisateur deja pris")
+    user_id = max([u["id"] for u in db["users"]] or [0]) + 1
+    password_hash = bcrypt.hashpw(user_in.password.encode(), bcrypt.gensalt()).decode()
+    user = {
+        "id": user_id,
+        "username": user_in.username,
+        "password_hash": password_hash,
+        "role": "intermittent",
+        "is_active": True,
+    }
+    db["users"].append(user)
+    save_db(db)
+    return UserOut(id=user_id, username=user_in.username, role="intermittent")
+
+
+@router.post("/token-json", response_model=TokenOut)
+def token_json(user_in: UserIn) -> TokenOut:
+    db = load_db()
+    user = next((u for u in db["users"] if u["username"] == user_in.username), None)
+    if not user or not bcrypt.checkpw(user_in.password.encode(), user["password_hash"].encode()):
+        raise HTTPException(status_code=401, detail="identifiants invalides")
+    token = f"tok_{user['id']}_{secrets.token_hex(8)}"
+    db["tokens"].append({
+        "token": token,
+        "user_id": user["id"],
+        "created_at": datetime.now(timezone.utc).isoformat(),
+    })
+    save_db(db)
+    return TokenOut(access_token=token)
+
+
+@router.get("/me", response_model=UserOut)
+def me(authorization: str | None = Header(None)) -> UserOut:
+    if not authorization or not authorization.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="token invalide")
+    token = authorization.split()[1]
+    db = load_db()
+    token_entry = next((t for t in db["tokens"] if t["token"] == token), None)
+    if not token_entry:
+        raise HTTPException(status_code=401, detail="token invalide")
+    user = next((u for u in db["users"] if u["id"] == token_entry["user_id"]), None)
+    if not user or not user.get("is_active", False):
+        raise HTTPException(status_code=401, detail="utilisateur inactif")
+    return UserOut(id=user["id"], username=user["username"], role=user["role"])

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,0 +1,18 @@
+from __future__ import annotations
+
+from pydantic import BaseModel
+
+
+class UserIn(BaseModel):
+    username: str
+    password: str
+
+
+class UserOut(BaseModel):
+    id: int
+    username: str
+    role: str
+
+
+class TokenOut(BaseModel):
+    access_token: str

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Any
+
+DB_PATH = Path("/data/data.json")
+
+
+def _ensure_db_file() -> None:
+    DB_PATH.parent.mkdir(parents=True, exist_ok=True)
+    if not DB_PATH.exists():
+        with DB_PATH.open("w", encoding="utf-8") as f:
+            json.dump({"users": [], "tokens": []}, f)
+
+
+def load_db() -> Dict[str, Any]:
+    """Load database from JSON file, creating it if missing."""
+    _ensure_db_file()
+    with DB_PATH.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def save_db(db: Dict[str, Any]) -> None:
+    """Persist database to JSON file."""
+    _ensure_db_file()
+    with DB_PATH.open("w", encoding="utf-8") as f:
+        json.dump(db, f)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]==0.30.0
 pydantic==2.8.2
 pytest==8.2.0
 bcrypt==4.1.3
+httpx==0.27.0

--- a/backend/tests/test_auth.py
+++ b/backend/tests/test_auth.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import asyncio
+import pytest
+from httpx import AsyncClient, ASGITransport
+
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
+from app.main import app
+
+DB_PATH = Path("/data/data.json")
+
+
+@pytest.fixture(autouse=True)
+def clean_db():
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+    yield
+    if DB_PATH.exists():
+        DB_PATH.unlink()
+
+
+def test_register_login_me_ok():
+    async def _run():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            res = await ac.post("/auth/register", json={"username": "alice", "password": "secret"})
+            assert res.status_code == 200
+            assert res.json() == {"id": 1, "username": "alice", "role": "intermittent"}
+
+            res = await ac.post("/auth/token-json", json={"username": "alice", "password": "secret"})
+            assert res.status_code == 200
+            token = res.json()["access_token"]
+
+            res = await ac.get("/auth/me", headers={"Authorization": f"Bearer {token}"})
+            assert res.status_code == 200
+            assert res.json() == {"id": 1, "username": "alice", "role": "intermittent"}
+    asyncio.run(_run())
+
+
+def test_register_duplicate_409():
+    async def _run():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            r1 = await ac.post("/auth/register", json={"username": "bob", "password": "pw"})
+            assert r1.status_code == 200
+            r2 = await ac.post("/auth/register", json={"username": "bob", "password": "pw"})
+            assert r2.status_code == 409
+            assert r2.json()["detail"] == "nom d'utilisateur deja pris"
+    asyncio.run(_run())
+
+
+def test_me_401_without_token():
+    async def _run():
+        async with AsyncClient(transport=ASGITransport(app=app), base_url="http://test") as ac:
+            res = await ac.get("/auth/me")
+            assert res.status_code == 401
+            assert res.json()["detail"] == "token invalide"
+    asyncio.run(_run())

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -1,5 +1,5 @@
 import os, sys
-sys.path.append(os.path.join(os.path.dirname(__file__), "..", "app"))
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
 from fastapi.testclient import TestClient
 from app.main import app
 


### PR DESCRIPTION
## Summary
- store users and tokens in JSON file with helpers
- add schemas and auth router for register/token-json/me endpoints
- document auth usage and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f73d7c9348330848fa4ea965c3c6d