### PR TITLE
feat(auth): register/token-json/me + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,14 +3,14 @@ Backend: FastAPI minimal.
 
 ## Run with Docker
 powershell:
-  scripts\\dev_up.ps1
-  scripts\\test_backend.ps1
-  scripts\\dev_down.ps1
+  scripts\dev_up.ps1
+  scripts\test_backend.ps1
+  scripts\dev_down.ps1
 
 Manual (no Docker):
   python -m venv .venv
-  . .\\.venv\\Scripts\\Activate.ps1
-  pip install -r backend\\requirements.txt
+  . .\.venv\Scripts\Activate.ps1
+  pip install -r backend\requirements.txt
   pytest -q
   uvicorn app.main:app --host 0.0.0.0 --port 8001
 
@@ -20,3 +20,9 @@ powershell:
   Invoke-RestMethod -Uri "$u/auth/register" -Method Post -Body (@{username='alice';password='secret'} | ConvertTo-Json) -ContentType "application/json"
   $tok = Invoke-RestMethod -Uri "$u/auth/token-json" -Method Post -Body (@{username='alice';password='secret'} | ConvertTo-Json) -ContentType "application/json"
   Invoke-RestMethod -Uri "$u/auth/me" -Headers @{Authorization="Bearer $($tok.access_token)"}
+
+curl:
+  u=http://localhost:8001
+  curl -X POST "$u/auth/register" -H "Content-Type: application/json" -d '{"username":"alice","password":"secret"}'
+  tok=$(curl -s -X POST "$u/auth/token-json" -H "Content-Type: application/json" -d '{"username":"alice","password":"secret"}' | jq -r .access_token)
+  curl "$u/auth/me" -H "Authorization: Bearer $tok"

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -14,6 +14,7 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 
 @router.post("/register", response_model=UserOut)
 def register(user_in: UserIn) -> UserOut:
+    """Create a new user with a unique username and hashed password."""
     db = load_db()
     if any(u["username"] == user_in.username for u in db["users"]):
         raise HTTPException(status_code=409, detail="nom d'utilisateur deja pris")
@@ -33,6 +34,7 @@ def register(user_in: UserIn) -> UserOut:
 
 @router.post("/token-json", response_model=TokenOut)
 def token_json(user_in: UserIn) -> TokenOut:
+    """Return an access token when provided valid user credentials."""
     db = load_db()
     user = next((u for u in db["users"] if u["username"] == user_in.username), None)
     if not user or not bcrypt.checkpw(user_in.password.encode(), user["password_hash"].encode()):
@@ -49,6 +51,7 @@ def token_json(user_in: UserIn) -> TokenOut:
 
 @router.get("/me", response_model=UserOut)
 def me(authorization: str | None = Header(None)) -> UserOut:
+    """Retrieve the current user from a bearer token."""
     if not authorization or not authorization.startswith("Bearer "):
         raise HTTPException(status_code=401, detail="token invalide")
     token = authorization.split()[1]


### PR DESCRIPTION
## Summary
- add descriptive docstrings to auth endpoints
- expand README with curl-based auth quickstart

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f779bae208330b98a348e2de1bb6d