### PR TITLE
feat(missions): CRUD + filters + pagination + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,17 @@ curl:
   curl -X POST "$u/auth/register" -H "Content-Type: application/json" -d '{"username":"alice","password":"secret"}'
   tok=$(curl -s -X POST "$u/auth/token-json" -H "Content-Type: application/json" -d '{"username":"alice","password":"secret"}' | jq -r .access_token)
   curl "$u/auth/me" -H "Authorization: Bearer $tok"
+
+## Missions
+powershell:
+  $u = "http://localhost:8001"
+  Invoke-RestMethod -Uri "$u/missions"
+  $m = @{title="Show";start="2025-08-16T08:00:00Z";end="2025-08-16T12:00:00Z";positions=@()} | ConvertTo-Json
+  Invoke-RestMethod -Uri "$u/missions" -Method Post -Headers @{Authorization="Bearer $tok"} -Body $m -ContentType "application/json"
+
+curl:
+  u=http://localhost:8001
+  curl "$u/missions"
+  curl -X POST "$u/missions" -H "Authorization: Bearer $tok" -H "Content-Type: application/json" -d '{"title":"Show","start":"2025-08-16T08:00:00Z","end":"2025-08-16T12:00:00Z","positions":[]}'
+
+Note: POST/PUT/DELETE /missions endpoints require a Bearer token.

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth
+from app.routers import auth, missions
 
 app = FastAPI(title="app_v1")
 
@@ -13,6 +13,7 @@ app.add_middleware(
 )
 
 app.include_router(auth.router)
+app.include_router(missions.router)
 
 @app.get("/healthz")
 def healthz():

--- a/backend/app/routers/missions.py
+++ b/backend/app/routers/missions.py
@@ -1,0 +1,141 @@
+from fastapi import APIRouter, HTTPException, Depends, Query
+from typing import List, Optional, Dict, Any
+from datetime import datetime
+from app.storage import load_db, save_db
+from app.schemas import MissionCreate, MissionUpdate, MissionOut
+from app.routers.auth import _current_user as current_user_dep  # reuse auth dep for protected writes
+
+router = APIRouter()
+
+
+def _ensure_missions(db: Dict[str, Any]) -> None:
+    db.setdefault("missions", [])
+
+
+def _next_id(items: List[Dict[str, Any]]) -> int:
+    return (max((x.get("id", 0) for x in items), default=0) + 1)
+
+
+def _to_out(m: Dict[str, Any]) -> MissionOut:
+    # Pydantic will coerce types
+    return MissionOut(**m)
+
+
+@router.get("/missions")
+def list_missions(
+    q: Optional[str] = None,
+    status: Optional[str] = Query(None, pattern="^(draft|published)$"),
+    date_from: Optional[datetime] = None,
+    date_to: Optional[datetime] = None,
+    page: int = Query(1, ge=1),
+    per_page: int = Query(20, ge=1, le=100),
+):
+    db = load_db()
+    _ensure_missions(db)
+    items = db["missions"]
+
+    def match(m: Dict[str, Any]) -> bool:
+        ok = True
+        if q:
+            qq = q.lower()
+            txt = (m.get("title", "") + " " + (m.get("location") or "")).lower()
+            ok = ok and (qq in txt)
+        if status:
+            ok = ok and (m.get("status") == status)
+        if date_from:
+            try:
+                ok = ok and (datetime.fromisoformat(m["start"]) >= date_from)
+            except Exception:
+                ok = False
+        if date_to:
+            try:
+                ok = ok and (datetime.fromisoformat(m["end"]) <= date_to)
+            except Exception:
+                ok = False
+        return ok
+
+    filtered = [m for m in items if match(m)]
+    filtered.sort(key=lambda m: m.get("start"))  # ISO strings sort well but keep simple
+
+    total = len(filtered)
+    start_idx = (page - 1) * per_page
+    end_idx = start_idx + per_page
+    slice_items = filtered[start_idx:end_idx]
+
+    return {
+        "items": [_to_out(m).model_dump() for m in slice_items],
+        "page": page,
+        "per_page": per_page,
+        "total": total,
+    }
+
+
+@router.post("/missions", response_model=MissionOut)
+def create_mission(payload: MissionCreate, user=Depends(current_user_dep)):
+    db = load_db()
+    _ensure_missions(db)
+    # Validate final times (MissionCreate already validates, but explicit check is fine)
+    if payload.end <= payload.start:
+        raise HTTPException(status_code=422, detail="end must be after start")
+    mid = _next_id(db["missions"])
+    m = payload.model_dump()
+    m["id"] = mid
+    # Serialize datetimes to isoformat
+    m["start"] = payload.start.isoformat()
+    m["end"] = payload.end.isoformat()
+    db["missions"].append(m)
+    save_db(db)
+    return _to_out(m)
+
+
+@router.get("/missions/{mid}", response_model=MissionOut)
+def get_mission(mid: int):
+    db = load_db()
+    _ensure_missions(db)
+    m = next((x for x in db["missions"] if x.get("id") == mid), None)
+    if not m:
+        raise HTTPException(status_code=404, detail="mission not found")
+    return _to_out(m)
+
+
+@router.put("/missions/{mid}", response_model=MissionOut)
+def update_mission(mid: int, payload: MissionUpdate, user=Depends(current_user_dep)):
+    db = load_db()
+    _ensure_missions(db)
+    idx = next((i for i, x in enumerate(db["missions"]) if x.get("id") == mid), None)
+    if idx is None:
+        raise HTTPException(status_code=404, detail="mission not found")
+    cur = dict(db["missions"][idx])
+
+    # Apply updates
+    data = payload.model_dump(exclude_unset=True)
+    for k, v in data.items():
+        if k in ("start", "end") and v is not None and hasattr(v, "isoformat"):
+            data[k] = v.isoformat()
+    cur.update(data)
+
+    # Re-validate combined times if both present (or after update)
+    try:
+        s = cur.get("start")
+        e = cur.get("end")
+        if s and e and datetime.fromisoformat(e) <= datetime.fromisoformat(s):
+            raise HTTPException(status_code=422, detail="end must be after start")
+    except ValueError:
+        raise HTTPException(status_code=422, detail="invalid datetime format")
+
+    db["missions"][idx] = cur
+    save_db(db)
+    return _to_out(cur)
+
+
+@router.delete("/missions/{mid}", status_code=204)
+def delete_mission(mid: int, user=Depends(current_user_dep)):
+    db = load_db()
+    _ensure_missions(db)
+    before = len(db["missions"])
+    db["missions"] = [x for x in db["missions"] if x.get("id") != mid]
+    if len(db["missions"]) == before:
+        raise HTTPException(status_code=404, detail="mission not found")
+    save_db(db)
+    return
+

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -1,4 +1,6 @@
-from pydantic import BaseModel
+from pydantic import BaseModel, Field, field_validator
+from typing import Optional, List, Dict
+from datetime import datetime
 
 class UserIn(BaseModel):
     username: str
@@ -11,3 +13,64 @@ class UserOut(BaseModel):
 
 class TokenOut(BaseModel):
     access_token: str
+
+
+class PositionIn(BaseModel):
+    label: str
+    count: int = Field(ge=1)
+    skills: Dict[str, str] = {}
+
+
+class MissionBase(BaseModel):
+    title: str
+    start: datetime
+    end: datetime
+    location: Optional[str] = None
+    status: str = Field(default="draft")
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status(cls, v: str) -> str:
+        if v not in ("draft", "published"):
+            raise ValueError("invalid status")
+        return v
+
+    @field_validator("end")
+    @classmethod
+    def _end_after_start(cls, v: datetime, info):
+        start = info.data.get("start")
+        if start is not None and v <= start:
+            raise ValueError("end must be after start")
+        return v
+
+
+class MissionCreate(MissionBase):
+    positions: List[PositionIn] = []
+
+
+class MissionUpdate(BaseModel):
+    title: Optional[str] = None
+    start: Optional[datetime] = None
+    end: Optional[datetime] = None
+    location: Optional[str] = None
+    status: Optional[str] = None
+    positions: Optional[List[PositionIn]] = None
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status_u(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in ("draft", "published"):
+            raise ValueError("invalid status")
+        return v
+
+    @field_validator("end")
+    @classmethod
+    def _end_after_start_u(cls, v: Optional[datetime], info):
+        start = info.data.get("start")
+        # If only end is provided, cannot validate here; router will re-validate combined
+        return v
+
+
+class MissionOut(MissionBase):
+    id: int
+    positions: List[PositionIn] = []

--- a/backend/tests/test_missions.py
+++ b/backend/tests/test_missions.py
@@ -1,0 +1,64 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), "..", "app"))
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def _token(c: TestClient) -> str:
+    c.post("/auth/register", json={"username": "u", "password": "p"})
+    r = c.post("/auth/token-json", json={"username": "u", "password": "p"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def test_create_list_update_delete_ok(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+
+    body = {
+        "title": "Show A",
+        "start": "2025-08-16T08:00:00+04:00",
+        "end": "2025-08-16T12:00:00+04:00",
+        "status": "draft",
+        "positions": [{"label": "SON", "count": 1, "skills": {}}],
+    }
+    r = c.post("/missions", json=body, headers=H)
+    assert r.status_code == 200, r.text
+    mid = r.json()["id"]
+
+    r = c.get("/missions")
+    assert r.status_code == 200
+    assert r.json()["total"] >= 1
+
+    # Update
+    r = c.put(f"/missions/{mid}", json={"status": "published"}, headers=H)
+    assert r.status_code == 200
+    assert r.json()["status"] == "published"
+
+    # Delete
+    r = c.delete(f"/missions/{mid}", headers=H)
+    assert r.status_code == 204
+
+    # Not found after delete
+    r = c.get(f"/missions/{mid}")
+    assert r.status_code == 404
+
+
+def test_create_invalid_dates_422(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+
+    body = {
+        "title": "Bad",
+        "start": "2025-08-16T12:00:00+04:00",
+        "end": "2025-08-16T08:00:00+04:00",
+        "status": "draft",
+        "positions": [],
+    }
+    r = c.post("/missions", json=body, headers=H)
+    assert r.status_code in (400, 422), r.text
+


### PR DESCRIPTION
## Summary
- add mission schemas with validation
- implement missions CRUD with filters and pagination
- mount missions router and document usage
- add tests for mission CRUD and invalid dates

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7b7f716c83308254ded8d97945a1