### PR TITLE
chore(dev): root requirements + ensure pytest in container + compose fix

### DIFF
--- a/agents.md
+++ b/agents.md
@@ -34,6 +34,9 @@ pytest==8.2.0
 bcrypt==4.1.3
 httpx==0.27.0
 
+## Requirements
+- Root requirements.txt includes backend/requirements.txt and is used by docker-compose to install dependencies.
+
 ## Local commands (Windows PowerShell)
 scripts\\dev_up.ps1
 scripts\\test_backend.ps1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,13 +1,12 @@
 services:
   api:
     image: python:3.11-slim
-    working_dir: /app/backend
+    working_dir: /app
     volumes:
-      - ./backend:/app/backend
+      - ./:/app
       - ./data:/data
     command: >
-      bash -lc "pip install -r requirements.txt &&
-                uvicorn app.main:app --host 0.0.0.0 --port 8001"
+      bash -lc "python -m pip install -U pip && pip install -r requirements.txt && cd backend && uvicorn app.main:app --host 0.0.0.0 --port 8001"
     ports:
       - "8001:8001"
     environment:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+-r backend/requirements.txt

--- a/scripts/test_backend.ps1
+++ b/scripts/test_backend.ps1
@@ -1,1 +1,3 @@
+docker compose exec api python -c "import pytest, httpx; print('deps-ok')"
+if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 docker compose exec api python -m pytest -q


### PR DESCRIPTION
## Summary
- add root requirements.txt referencing backend requirements
- fix docker-compose to install deps from root and expose dev port
- update PowerShell test script to verify pytest/httpx before running tests
- document root requirements usage in AGENTS guide

## Testing
- `docker compose up -d --build` *(fails: command not found)*
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f7cc12fe8833093d61de3c34f129f