### PR TITLE
chore(docker): build-time deps via Dockerfile (copy requirements) to ensure pytest in container

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,20 @@
+FROM python:3.11-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1
+ENV PYTHONUNBUFFERED=1
+
+WORKDIR /app
+
+# copy requirements into image and install once (build-time)
+COPY requirements.txt /tmp/requirements.txt
+COPY backend/requirements.txt /tmp/backend_requirements.txt
+RUN python -m pip install -U pip && \
+    pip install -r /tmp/requirements.txt
+
+# create runtime data dir
+RUN mkdir -p /data
+
+# code will be mounted in dev; keep a default workdir for uvicorn
+WORKDIR /app/backend
+
+CMD ["bash","-lc","uvicorn app.main:app --host 0.0.0.0 --port 8001"]

--- a/agents.md
+++ b/agents.md
@@ -35,7 +35,8 @@ bcrypt==4.1.3
 httpx==0.27.0
 
 ## Requirements
-- Root requirements.txt includes backend/requirements.txt and is used by docker-compose to install dependencies.
+- Root requirements.txt includes backend/requirements.txt.
+- Dependencies are installed at build time via Dockerfile.api, so pytest and httpx are always present inside the container.
 
 ## Local commands (Windows PowerShell)
 scripts\\dev_up.ps1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,13 @@
 services:
   api:
-    image: python:3.11-slim
-    working_dir: /app
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    working_dir: /app/backend
     volumes:
       - ./:/app
       - ./data:/data
-    command: >
-      bash -lc "python -m pip install -U pip && pip install -r requirements.txt && cd backend && uvicorn app.main:app --host 0.0.0.0 --port 8001"
+    command: bash -lc "uvicorn app.main:app --host 0.0.0.0 --port 8001"
     ports:
       - "8001:8001"
     environment:

--- a/scripts/test_backend.ps1
+++ b/scripts/test_backend.ps1
@@ -1,3 +1,1 @@
-docker compose exec api python -c "import pytest, httpx; print('deps-ok')"
-if ($LASTEXITCODE -ne 0) { exit $LASTEXITCODE }
 docker compose exec api python -m pytest -q


### PR DESCRIPTION
## Summary
- build API image using Dockerfile.api and copy requirements at build time
- remove runtime pip install from docker-compose and simplify test script
- document build-time dependency install in agents guide

## Testing
- `docker compose down -v --remove-orphans` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `docker compose build --no-cache` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `docker compose up -d` *(fails: unable to get image 'app_v1-api': Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*
- `docker compose exec api python -m pytest -q` *(fails: Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?)*

------
https://chatgpt.com/codex/tasks/task_e_689f7ec391fc83309996ba0d37cf67da