### PR TITLE
feat(assignments): POST/GET/DELETE with capacity checks + tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, missions
+from app.routers import auth, missions, assignments
 
 app = FastAPI(title="app_v1")
 
@@ -14,6 +14,7 @@ app.add_middleware(
 
 app.include_router(auth.router)
 app.include_router(missions.router)
+app.include_router(assignments.router)
 
 @app.get("/healthz")
 def healthz():

--- a/backend/app/routers/assignments.py
+++ b/backend/app/routers/assignments.py
@@ -1,0 +1,90 @@
+from fastapi import APIRouter, HTTPException, Depends
+from typing import Dict, Any, List
+from app.storage import load_db, save_db
+from app.schemas import AssignmentIn, AssignmentOut
+from app.routers.auth import _current_user as current_user_dep
+
+router = APIRouter()
+
+
+def _ensure_missions(db: Dict[str, Any]) -> None:
+    db.setdefault("missions", [])
+
+
+def _ensure_assignments(db: Dict[str, Any]) -> None:
+    db.setdefault("assignments", [])
+
+
+def _next_id(items: List[Dict[str, Any]]) -> int:
+    return (max((x.get("id", 0) for x in items), default=0) + 1)
+
+
+def _to_out(a: Dict[str, Any]) -> AssignmentOut:
+    return AssignmentOut(**a)
+
+
+@router.post("/missions/{mid}/assign", response_model=AssignmentOut)
+def create_assignment(mid: int, payload: AssignmentIn, user=Depends(current_user_dep)):
+    db = load_db()
+    _ensure_missions(db)
+    _ensure_assignments(db)
+    mission = next((m for m in db["missions"] if m.get("id") == mid), None)
+    if not mission:
+        raise HTTPException(status_code=404, detail="mission not found")
+    pos = next((p for p in mission.get("positions", []) if p.get("label") == payload.role_label), None)
+    if not pos:
+        raise HTTPException(status_code=422, detail="invalid role_label")
+    existing = [
+        a for a in db["assignments"]
+        if a.get("mission_id") == mid and a.get("role_label") == payload.role_label
+    ]
+    if len(existing) >= pos.get("count", 0):
+        raise HTTPException(status_code=422, detail="capacity exceeded")
+    aid = _next_id(db["assignments"])
+    a = {
+        "id": aid,
+        "mission_id": mid,
+        "user_id": payload.user_id,
+        "role_label": payload.role_label,
+        "status": payload.status,
+    }
+    db["assignments"].append(a)
+    save_db(db)
+    return _to_out(a)
+
+
+@router.get("/missions/{mid}/assignments")
+def list_assignments(mid: int):
+    db = load_db()
+    _ensure_missions(db)
+    _ensure_assignments(db)
+    mission = next((m for m in db["missions"] if m.get("id") == mid), None)
+    if not mission:
+        raise HTTPException(status_code=404, detail="mission not found")
+    items = [
+        _to_out(a).model_dump() for a in db["assignments"] if a.get("mission_id") == mid
+    ]
+    return {"items": items, "total": len(items)}
+
+
+@router.delete("/missions/{mid}/assignments/{aid}", status_code=204)
+def delete_assignment(mid: int, aid: int, user=Depends(current_user_dep)):
+    db = load_db()
+    _ensure_missions(db)
+    _ensure_assignments(db)
+    mission = next((m for m in db["missions"] if m.get("id") == mid), None)
+    if not mission:
+        raise HTTPException(status_code=404, detail="mission not found")
+    idx = next(
+        (
+            i
+            for i, a in enumerate(db["assignments"])
+            if a.get("id") == aid and a.get("mission_id") == mid
+        ),
+        None,
+    )
+    if idx is None:
+        raise HTTPException(status_code=404, detail="assignment not found")
+    db["assignments"].pop(idx)
+    save_db(db)
+    return

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -74,3 +74,33 @@ class MissionUpdate(BaseModel):
 class MissionOut(MissionBase):
     id: int
     positions: List[PositionIn] = []
+
+
+class AssignmentIn(BaseModel):
+    role_label: str
+    user_id: int
+    status: str = "invited"
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status_a(cls, v: str) -> str:
+        allowed = {"invited", "confirmed", "declined", "tentative"}
+        if v not in allowed:
+            raise ValueError("invalid status")
+        return v
+
+
+class AssignmentOut(BaseModel):
+    id: int
+    mission_id: int
+    user_id: int
+    role_label: str
+    status: str
+
+    @field_validator("status")
+    @classmethod
+    def _valid_status_o(cls, v: str) -> str:
+        allowed = {"invited", "confirmed", "declined", "tentative"}
+        if v not in allowed:
+            raise ValueError("invalid status")
+        return v

--- a/backend/tests/test_assignments.py
+++ b/backend/tests/test_assignments.py
@@ -1,0 +1,67 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from fastapi.testclient import TestClient
+from app.main import app
+
+
+def _token(c: TestClient) -> str:
+    c.post("/auth/register", json={"username": "u", "password": "p"})
+    r = c.post("/auth/token-json", json={"username": "u", "password": "p"})
+    assert r.status_code == 200, r.text
+    return r.json()["access_token"]
+
+
+def _mission(c: TestClient, headers):
+    body = {
+        "title": "Show A",
+        "start": "2025-08-16T08:00:00+04:00",
+        "end": "2025-08-16T12:00:00+04:00",
+        "status": "draft",
+        "positions": [{"label": "SON", "count": 1, "skills": {}}],
+    }
+    r = c.post("/missions", json=body, headers=headers)
+    assert r.status_code == 200, r.text
+    return r.json()["id"]
+
+
+def test_assign_ok_then_capacity_exceeded_422(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    mid = _mission(c, H)
+
+    r = c.post(f"/missions/{mid}/assign", json={"role_label": "SON", "user_id": 1}, headers=H)
+    assert r.status_code == 200, r.text
+
+    r = c.post(f"/missions/{mid}/assign", json={"role_label": "SON", "user_id": 2}, headers=H)
+    assert r.status_code == 422
+
+
+def test_assign_invalid_role_422(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    mid = _mission(c, H)
+
+    r = c.post(f"/missions/{mid}/assign", json={"role_label": "DRUM", "user_id": 1}, headers=H)
+    assert r.status_code == 422
+
+
+def test_delete_assignment_204_and_404(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    mid = _mission(c, H)
+
+    r = c.post(f"/missions/{mid}/assign", json={"role_label": "SON", "user_id": 1}, headers=H)
+    assert r.status_code == 200, r.text
+    aid = r.json()["id"]
+
+    r = c.delete(f"/missions/{mid}/assignments/{aid}", headers=H)
+    assert r.status_code == 204
+
+    r = c.delete(f"/missions/{mid}/assignments/{aid}", headers=H)
+    assert r.status_code == 404


### PR DESCRIPTION
## Summary
- add AssignmentIn and AssignmentOut schemas with status validation
- implement assignment create, list, and delete endpoints with capacity checks
- cover assignment flows with tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f80d318fc8330a7ede458607367dc