### PR TITLE
feat(admin): users list/get/put/soft-delete + reset + tests

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,6 +1,6 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
-from app.routers import auth, missions, assignments
+from app.routers import auth, missions, assignments, admin
 
 app = FastAPI(title="app_v1")
 
@@ -15,6 +15,7 @@ app.add_middleware(
 app.include_router(auth.router)
 app.include_router(missions.router)
 app.include_router(assignments.router)
+app.include_router(admin.router)
 
 @app.get("/healthz")
 def healthz():

--- a/backend/app/routers/admin.py
+++ b/backend/app/routers/admin.py
@@ -1,0 +1,88 @@
+from fastapi import APIRouter, HTTPException, Depends
+from typing import Optional, Dict, Any
+from datetime import datetime, timezone
+from app.storage import load_db, save_db
+from app.schemas import UserOut, UserAdminUpdate
+from app.routers.auth import _current_user as current_user_dep
+
+router = APIRouter()
+
+
+def _admin_user(user: Dict[str, Any] = Depends(current_user_dep)) -> Dict[str, Any]:
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="forbidden")
+    return user
+
+
+def _to_out(u: Dict[str, Any]) -> UserOut:
+    return UserOut(
+        id=u["id"],
+        username=u["username"],
+        role=u.get("role", "intermittent"),
+        is_active=u.get("is_active", True),
+    )
+
+
+@router.get("/admin/users")
+def list_users(
+    q: Optional[str] = None,
+    page: int = 1,
+    per_page: int = 10,
+    user: Dict[str, Any] = Depends(_admin_user),
+):
+    db = load_db()
+    users = [u for u in db.get("users", []) if not u.get("deleted_at")]
+    if q:
+        ql = q.lower()
+        users = [u for u in users if ql in u.get("username", "").lower()]
+    total = len(users)
+    start = (page - 1) * per_page
+    end = start + per_page
+    items = [_to_out(u).model_dump() for u in users[start:end]]
+    return {"items": items, "page": page, "per_page": per_page, "total": total}
+
+
+@router.get("/admin/users/{uid}", response_model=UserOut)
+def get_user(uid: int, user: Dict[str, Any] = Depends(_admin_user)):
+    db = load_db()
+    u = next((u for u in db.get("users", []) if u.get("id") == uid and not u.get("deleted_at")), None)
+    if not u:
+        raise HTTPException(status_code=404, detail="user not found")
+    return _to_out(u)
+
+
+@router.put("/admin/users/{uid}", response_model=UserOut)
+def update_user(uid: int, payload: UserAdminUpdate, user: Dict[str, Any] = Depends(_admin_user)):
+    db = load_db()
+    users = db.get("users", [])
+    idx = next((i for i, u in enumerate(users) if u.get("id") == uid and not u.get("deleted_at")), None)
+    if idx is None:
+        raise HTTPException(status_code=404, detail="user not found")
+    cur = dict(users[idx])
+    if payload.role is not None:
+        cur["role"] = payload.role
+    if payload.is_active is not None:
+        cur["is_active"] = payload.is_active
+    users[idx] = cur
+    save_db(db)
+    return _to_out(cur)
+
+
+@router.delete("/admin/users/{uid}", status_code=204)
+def delete_user(uid: int, user: Dict[str, Any] = Depends(_admin_user)):
+    db = load_db()
+    u = next((u for u in db.get("users", []) if u.get("id") == uid and not u.get("deleted_at")), None)
+    if not u:
+        raise HTTPException(status_code=404, detail="user not found")
+    u["deleted_at"] = datetime.now(timezone.utc).isoformat()
+    u["is_active"] = False
+    save_db(db)
+    return
+
+
+@router.post("/admin/reset")
+def reset(user: Dict[str, Any] = Depends(_admin_user)):
+    db = {"users": [], "tokens": [], "missions": [], "assignments": []}
+    save_db(db)
+    return {"ok": True}
+

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -34,7 +34,12 @@ def register(payload: UserIn):
     }
     db["users"].append(user)
     save_db(db)
-    return {"id": next_id, "username": payload.username, "role": "intermittent"}
+    return {
+        "id": next_id,
+        "username": payload.username,
+        "role": "intermittent",
+        "is_active": True,
+    }
 
 @router.post("/auth/token-json", response_model=TokenOut)
 def token_json(payload: UserIn):
@@ -64,4 +69,9 @@ def _current_user(authorization: Optional[str] = Header(None)) -> Dict[str, Any]
 
 @router.get("/auth/me", response_model=UserOut)
 def me(user: Dict[str, Any] = Depends(_current_user)):
-    return {"id": user["id"], "username": user["username"], "role": user.get("role", "intermittent")}
+    return {
+        "id": user["id"],
+        "username": user["username"],
+        "role": user.get("role", "intermittent"),
+        "is_active": user.get("is_active", True),
+    }

--- a/backend/app/schemas.py
+++ b/backend/app/schemas.py
@@ -10,6 +10,19 @@ class UserOut(BaseModel):
     id: int
     username: str
     role: str
+    is_active: bool
+
+
+class UserAdminUpdate(BaseModel):
+    role: Optional[str] = None
+    is_active: Optional[bool] = None
+
+    @field_validator("role")
+    @classmethod
+    def _valid_role(cls, v: Optional[str]) -> Optional[str]:
+        if v is not None and v not in {"admin", "intermittent"}:
+            raise ValueError("invalid role")
+        return v
 
 class TokenOut(BaseModel):
     access_token: str

--- a/backend/app/storage.py
+++ b/backend/app/storage.py
@@ -14,7 +14,7 @@ def _db_path() -> str:
 def _init_if_missing(path: str) -> None:
     if not os.path.exists(path):
         with open(path, "w", encoding="utf-8") as f:
-            json.dump({"users": [], "tokens": []}, f)
+            json.dump({"users": [], "tokens": [], "missions": [], "assignments": []}, f)
 
 def load_db() -> Dict[str, Any]:
     path = _db_path()

--- a/backend/tests/test_admin.py
+++ b/backend/tests/test_admin.py
@@ -1,0 +1,68 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from fastapi.testclient import TestClient
+from app.main import app
+from app.storage import load_db, save_db
+
+
+def _admin_token(c: TestClient) -> str:
+    c.post("/auth/register", json={"username": "admin", "password": "pw"})
+    db = load_db()
+    db["users"][0]["role"] = "admin"
+    save_db(db)
+    r = c.post("/auth/token-json", json={"username": "admin", "password": "pw"})
+    return r.json()["access_token"]
+
+
+def test_admin_list_get_put_delete_ok_as_admin(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _admin_token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    c.post("/auth/register", json={"username": "u1", "password": "p"})
+    c.post("/auth/register", json={"username": "u2", "password": "p"})
+    db = load_db()
+    uid = next(u["id"] for u in db["users"] if u["username"] == "u1")
+
+    r = c.get("/admin/users", headers=H)
+    assert r.status_code == 200
+    total = r.json()["total"]
+    assert any(u["username"] == "u1" for u in r.json()["items"])
+
+    r = c.get(f"/admin/users/{uid}", headers=H)
+    assert r.status_code == 200
+    assert r.json()["username"] == "u1"
+
+    r = c.put(f"/admin/users/{uid}", json={"role": "admin", "is_active": False}, headers=H)
+    assert r.status_code == 200
+    assert r.json()["role"] == "admin"
+    assert r.json()["is_active"] is False
+
+    r = c.delete(f"/admin/users/{uid}", headers=H)
+    assert r.status_code == 204
+
+    r = c.get(f"/admin/users/{uid}", headers=H)
+    assert r.status_code == 404
+
+    r = c.get("/admin/users", headers=H)
+    assert r.json()["total"] == total - 1
+
+    db = load_db()
+    du = next(u for u in db["users"] if u["id"] == uid)
+    assert du["is_active"] is False and du.get("deleted_at")
+
+    r = c.post("/admin/reset", headers=H)
+    assert r.status_code == 200
+    assert r.json()["ok"] is True
+    assert load_db() == {"users": [], "tokens": [], "missions": [], "assignments": []}
+
+
+def test_non_admin_forbidden(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    c.post("/auth/register", json={"username": "u", "password": "p"})
+    r = c.post("/auth/token-json", json={"username": "u", "password": "p"})
+    tok = r.json()["access_token"]
+    H = {"Authorization": f"Bearer {tok}"}
+    r = c.get("/admin/users", headers=H)
+    assert r.status_code == 403


### PR DESCRIPTION
## Summary
- add admin router with user management and database reset endpoints
- extend user schemas and auth responses to expose `is_active`
- seed storage with mission and assignment collections
- cover admin-only flows with new tests

## Testing
- `cd backend && python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f831c3e088330aed40b7010628218