### PR TITLE
ci: backend pytest on GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+      - name: Install deps
+        run: |
+          python -m pip install -U pip
+          pip install -r requirements.txt
+      - name: Run tests
+        run: |
+          python -m pytest -q

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # app_v1
+[![CI](https://github.com/OWNER/REPO/actions/workflows/ci.yml/badge.svg)](https://github.com/OWNER/REPO/actions/workflows/ci.yml)
 Backend: FastAPI minimal.
+
+## CI
+GitHub Actions runs `python -m pytest -q` for pushes and pull requests.
 
 ## Run with Docker
 powershell:


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow running pytest on Python 3.11
- document CI status badge and steps in README

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_689f8b199ff08330ae0e2783513c3aa7