### PR TITLE
feat(front): Vite React TS + API services/hooks (auth, missions) + compose web

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,18 @@ Manual (no Docker):
   pytest -q
   uvicorn app.main:app --host 0.0.0.0 --port 8001
 
+## Frontend
+Docker:
+  docker compose up -d --build
+  browse http://localhost:5173
+
+Local:
+  cd frontend
+  npm i
+  npm run dev
+
+Set `VITE_API_URL` to point to the API (defaults to http://localhost:8001). Token persists in `localStorage`.
+
 ## Auth quickstart
 powershell:
   $u = "http://localhost:8001"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,16 @@ services:
       - "8001:8001"
     environment:
       - PYTHONUNBUFFERED=1
+  web:
+    image: node:20
+    working_dir: /app/frontend
+    volumes:
+      - ./:/app
+    command: bash -lc "npm ci || npm i && npm run build && npm run preview -- --host --port 5173"
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api
 
 volumes:
   data:

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8001

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Frontend</title>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="/src/main.tsx"></script>
+  </body>
+</html>

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "frontend",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc -b && vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "react": "^19.1.1",
+    "react-dom": "^19.1.1"
+  },
+  "devDependencies": {
+    "@types/react": "^19.1.10",
+    "@types/react-dom": "^19.1.7",
+    "@vitejs/plugin-react": "^5.0.0",
+    "typescript": "~5.8.3",
+    "vite": "^7.1.2"
+  }
+}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,0 +1,89 @@
+import { useState, useEffect } from "react";
+import { useAuth } from "./hooks/useAuth";
+import { listMissions, createMission } from "./services/missions";
+
+function App() {
+  const { token, login, logout } = useAuth();
+  const [username, setUsername] = useState("");
+  const [password, setPassword] = useState("");
+  const [missions, setMissions] = useState<any[]>([]);
+
+  useEffect(() => {
+    if (!token) return;
+    listMissions()
+      .then((r) => {
+        const items = Array.isArray(r) ? r : r.items;
+        setMissions(items || []);
+      })
+      .catch(console.error);
+  }, [token]);
+
+  async function handleLogin(e: React.FormEvent) {
+    e.preventDefault();
+    try {
+      await login(username, password);
+      setUsername("");
+      setPassword("");
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  async function handleNew() {
+    const now = new Date();
+    const later = new Date(now.getTime() + 2 * 60 * 60 * 1000);
+    const m = {
+      title: "Demo",
+      start: now.toISOString(),
+      end: later.toISOString(),
+      status: "draft",
+      positions: [{ label: "SON", count: 1, skills: {} }],
+    };
+    try {
+      await createMission(m);
+      const r = await listMissions();
+      const items = Array.isArray(r) ? r : r.items;
+      setMissions(items || []);
+    } catch (err) {
+      console.error(err);
+    }
+  }
+
+  return (
+    <div>
+      <header>
+        {token ? (
+          <button onClick={logout}>Logout</button>
+        ) : (
+          <form onSubmit={handleLogin}>
+            <input
+              placeholder="username"
+              value={username}
+              onChange={(e) => setUsername(e.target.value)}
+            />
+            <input
+              placeholder="password"
+              type="password"
+              value={password}
+              onChange={(e) => setPassword(e.target.value)}
+            />
+            <button type="submit">Login</button>
+          </form>
+        )}
+      </header>
+      {token && (
+        <main>
+          <h2>Missions</h2>
+          <button onClick={handleNew}>New mission</button>
+          <ul>
+            {missions.map((m, i) => (
+              <li key={m.id || i}>{m.title || JSON.stringify(m)}</li>
+            ))}
+          </ul>
+        </main>
+      )}
+    </div>
+  );
+}
+
+export default App;

--- a/frontend/src/hooks/useAuth.ts
+++ b/frontend/src/hooks/useAuth.ts
@@ -1,0 +1,19 @@
+import { useState } from "react";
+import * as auth from "../services/auth";
+
+export function useAuth() {
+  const [token, setToken] = useState<string | null>(() => localStorage.getItem("token"));
+
+  async function login(username: string, password: string) {
+    const res = await auth.login(username, password);
+    setToken(localStorage.getItem("token"));
+    return res;
+  }
+
+  function logout() {
+    auth.logout();
+    setToken(null);
+  }
+
+  return { token, login, logout, me: auth.me };
+}

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,0 +1,19 @@
+export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8001";
+
+function authHeader() {
+  const t = localStorage.getItem("token");
+  return t ? { Authorization: "Bearer " + t } : {};
+}
+
+export async function api(path: string, init: RequestInit = {}) {
+  const r = await fetch(API_URL + path, {
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init.headers || {}),
+      ...authHeader(),
+    },
+  });
+  if (!r.ok) throw new Error("HTTP " + r.status);
+  return r.status === 204 ? null : r.json();
+}

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,0 +1,9 @@
+import { StrictMode } from "react";
+import { createRoot } from "react-dom/client";
+import App from "./App";
+
+createRoot(document.getElementById("root")!).render(
+  <StrictMode>
+    <App />
+  </StrictMode>
+);

--- a/frontend/src/services/auth.ts
+++ b/frontend/src/services/auth.ts
@@ -1,0 +1,25 @@
+import { api } from "../lib/api";
+
+export async function login(username: string, password: string) {
+  const res = await api("/auth/token-json", {
+    method: "POST",
+    body: JSON.stringify({ username, password }),
+  });
+  localStorage.setItem("token", res.access_token);
+  return res;
+}
+
+export async function register(username: string, password: string) {
+  return api("/auth/register", {
+    method: "POST",
+    body: JSON.stringify({ username, password }),
+  });
+}
+
+export async function me() {
+  return api("/auth/me");
+}
+
+export function logout() {
+  localStorage.removeItem("token");
+}

--- a/frontend/src/services/missions.ts
+++ b/frontend/src/services/missions.ts
@@ -1,0 +1,12 @@
+import { api } from "../lib/api";
+
+export async function listMissions() {
+  return api("/missions");
+}
+
+export async function createMission(m: any) {
+  return api("/missions", {
+    method: "POST",
+    body: JSON.stringify(m),
+  });
+}

--- a/frontend/src/vite-env.d.ts
+++ b/frontend/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,0 +1,27 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+    "target": "ES2022",
+    "useDefineForClassFields": true,
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+    "jsx": "react-jsx",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src"]
+}

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "files": [],
+  "references": [
+    { "path": "./tsconfig.app.json" },
+    { "path": "./tsconfig.node.json" }
+  ]
+}

--- a/frontend/tsconfig.node.json
+++ b/frontend/tsconfig.node.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2023",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "verbatimModuleSyntax": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "erasableSyntaxOnly": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite'
+import react from '@vitejs/plugin-react'
+
+// https://vite.dev/config/
+export default defineConfig({
+  plugins: [react()],
+})

--- a/scripts/dev_up.ps1
+++ b/scripts/dev_up.ps1
@@ -1,1 +1,1 @@
-docker compose up -d --build
+docker compose up -d --build api web


### PR DESCRIPTION
## Summary
- scaffold React + TypeScript frontend with fetch helpers and auth/missions services
- wire simple auth hook and missions UI
- add web service to docker-compose and update dev scripts/docs

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689f8c5e98788330951814ee82d81a9a