### PR TITLE
fix: type headers

### DIFF
--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -1,6 +1,6 @@
 export const API_URL = import.meta.env.VITE_API_URL || "http://localhost:8001";
 
-function authHeader() {
+function authHeader(): HeadersInit {
   const t = localStorage.getItem("token");
   return t ? { Authorization: "Bearer " + t } : {};
 }


### PR DESCRIPTION
## Summary
- type auth header as `HeadersInit`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689f96513cb48330a4e47b8d1acc46ff