### PR TITLE
feat: add CORS_ORIGINS and TOKEN_TTL env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ Set `VITE_API_URL` to point to the API (defaults to http://localhost:8001). Toke
 
 ## Environment variables
 - `DATA_DIR`: path for JSON storage (default `./data` with Docker)
-- `ALLOWED_ORIGINS`: comma-separated origins for CORS, `*` allows all (default `*`)
-- `TOKEN_TTL_HOURS`: token expiration in hours (default `24`)
+- `CORS_ORIGINS`: comma-separated origins for CORS, `*` allows all (default `*`)
+- `TOKEN_TTL`: token expiration in minutes (default `1440`)
 
 ## Auth quickstart
 powershell:

--- a/agents.md
+++ b/agents.md
@@ -54,8 +54,8 @@ curl -s http://localhost:8001/healthz
 
 ## Environment variables
 - DATA_DIR (optional): overrides /data path inside API container.
-- ALLOWED_ORIGINS (optional): comma-separated CORS origins (default "*").
-- TOKEN_TTL_HOURS (optional): token expiration in hours (default 24).
+- CORS_ORIGINS (optional): comma-separated CORS origins (default "*").
+- TOKEN_TTL (optional): token expiration in minutes (default 1440).
 - VITE_API_URL (reserved for future frontend).
 
 ## Storage model (JSON at /data/data.json)

--- a/backend/app/config.py
+++ b/backend/app/config.py
@@ -1,4 +1,4 @@
 import os
 
-ALLOWED_ORIGINS = os.environ.get("ALLOWED_ORIGINS", "*")
-TOKEN_TTL_HOURS = int(os.environ.get("TOKEN_TTL_HOURS", "24"))
+CORS_ORIGINS = os.environ.get("CORS_ORIGINS", "*")
+TOKEN_TTL = int(os.environ.get("TOKEN_TTL", "1440"))

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -5,10 +5,10 @@ from app.routers import auth, missions, assignments, admin
 
 app = FastAPI(title="app_v1")
 
-if config.ALLOWED_ORIGINS == "*":
+if config.CORS_ORIGINS == "*":
     origins = ["*"]
 else:
-    origins = [o.strip() for o in config.ALLOWED_ORIGINS.split(",") if o.strip()]
+    origins = [o.strip() for o in config.CORS_ORIGINS.split(",") if o.strip()]
 
 app.add_middleware(
     CORSMiddleware,

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -64,7 +64,7 @@ def _current_user(authorization: Optional[str] = Header(None)) -> Dict[str, Any]
     if not t:
         raise HTTPException(status_code=401, detail="Invalid token")
     created_at = datetime.fromisoformat(t.get("created_at"))
-    ttl = timedelta(hours=config.TOKEN_TTL_HOURS)
+    ttl = timedelta(minutes=config.TOKEN_TTL)
     if created_at + ttl <= datetime.now(timezone.utc):
         raise HTTPException(status_code=401, detail="Token expired")
     user = next((u for u in db.get("users", []) if u["id"] == t["user_id"]), None)

--- a/backend/tests/test_auth_ttl.py
+++ b/backend/tests/test_auth_ttl.py
@@ -1,18 +1,25 @@
-import os, sys, json
+import os, sys, json, importlib
+from datetime import datetime, timedelta, timezone
 sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
-from fastapi.testclient import TestClient
-from app.main import app
+
 
 def test_token_expired(tmp_path, monkeypatch):
     monkeypatch.setenv("DATA_DIR", str(tmp_path))
-    c = TestClient(app)
-    c.post("/auth/register", json={"username":"u","password":"p"})
-    r = c.post("/auth/token-json", json={"username":"u","password":"p"})
+    monkeypatch.setenv("TOKEN_TTL", "1")
+    from fastapi.testclient import TestClient
+    from app import config
+    import app.main as main
+    importlib.reload(config)
+    importlib.reload(main)
+    c = TestClient(main.app)
+    c.post("/auth/register", json={"username": "u", "password": "p"})
+    r = c.post("/auth/token-json", json={"username": "u", "password": "p"})
     tok = r.json()["access_token"]
     db_path = tmp_path / "data.json"
     with open(db_path, "r", encoding="utf-8") as f:
         db = json.load(f)
-    db["tokens"][0]["created_at"] = "2000-01-01T00:00:00+00:00"
+    old = datetime.now(timezone.utc) - timedelta(minutes=2)
+    db["tokens"][0]["created_at"] = old.isoformat()
     with open(db_path, "w", encoding="utf-8") as f:
         json.dump(db, f, ensure_ascii=True, indent=2)
     r = c.get("/auth/me", headers={"Authorization": f"Bearer {tok}"})

--- a/backend/tests/test_cors.py
+++ b/backend/tests/test_cors.py
@@ -1,0 +1,15 @@
+import os, sys, importlib
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+
+
+def test_cors_origins_env(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("CORS_ORIGINS", "http://example.com")
+    from fastapi.testclient import TestClient
+    from app import config
+    import app.main as main
+    importlib.reload(config)
+    importlib.reload(main)
+    c = TestClient(main.app)
+    r = c.get("/healthz", headers={"Origin": "http://example.com"})
+    assert r.headers["access-control-allow-origin"] == "http://example.com"


### PR DESCRIPTION
## Summary
- support CORS_ORIGINS env var for CORS middleware
- support TOKEN_TTL env var (minutes) for auth tokens
- document new environment variables and add tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f96f254a883308953c2402c74e5cb