### PR TITLE
feat(admin): backup/restore JSON + scripts + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,3 +77,12 @@ bash:
 - `POST /auth/me/notify-test` (Bearer) test notification channels; returns `{ok,dry_run,channels}`
 - `GET /admin/notifications/diagnostic` (admin) count users with prefs
 - `POST /admin/notifications/diagnostic/test` (admin) dry-run test for all users
+
+## Backup/Restore
+- `GET /admin/backup` (admin) download JSON backup
+- `POST /admin/restore?wipe=true|false` (admin) restore from JSON; `wipe=false` merges
+powershell:
+  $env:TOKEN = "...admin token..."
+  scripts\backup.ps1
+  scripts\restore.ps1 -File backup_20240101_000000.json
+  scripts\restore.ps1 -File backup_20240101_000000.json -NoWipe

--- a/agents.md
+++ b/agents.md
@@ -103,6 +103,12 @@ $t = Invoke-RestMethod -Uri http://localhost:8001/auth/token-json -Method Post -
 $hdr = @{ Authorization = "Bearer $($t.access_token)" }
 Invoke-RestMethod -Uri http://localhost:8001/auth/me -Headers $hdr
 
+## Backup/Restore
+PowerShell:
+scripts\\backup.ps1
+scripts\\restore.ps1 -File backup_20240101_000000.json
+scripts\\restore.ps1 -File backup_20240101_000000.json -NoWipe
+
 ## Do and Do not (for agents)
 DO:
 - Keep tests green (pytest -q).

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,7 +1,7 @@
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from app import config
-from app.routers import auth, missions, assignments, admin
+from app.routers import auth, missions, assignments, admin, admin_backup
 
 app = FastAPI(title="app_v1")
 
@@ -22,6 +22,7 @@ app.include_router(auth.router)
 app.include_router(missions.router)
 app.include_router(assignments.router)
 app.include_router(admin.router)
+app.include_router(admin_backup.router)
 
 @app.get("/healthz")
 def healthz():

--- a/backend/app/routers/admin_backup.py
+++ b/backend/app/routers/admin_backup.py
@@ -1,0 +1,66 @@
+from fastapi import APIRouter, Depends, HTTPException, Body
+from fastapi.responses import JSONResponse
+from typing import Dict, Any
+from datetime import datetime, timezone
+from app.storage import load_db, save_db
+from app.routers.auth import _current_user as current_user_dep
+
+router = APIRouter()
+
+
+def _admin_user(user: Dict[str, Any] = Depends(current_user_dep)) -> Dict[str, Any]:
+    if user.get("role") != "admin":
+        raise HTTPException(status_code=403, detail="forbidden")
+    return user
+
+
+@router.get("/admin/backup")
+def backup(user: Dict[str, Any] = Depends(_admin_user)):
+    db = load_db()
+    payload = {
+        "users": db.get("users", []),
+        "tokens": db.get("tokens", []),
+        "missions": db.get("missions", []),
+        "assignments": db.get("assignments", []),
+    }
+    now = datetime.now(timezone.utc)
+    data = {
+        "version": 1,
+        "created_at": now.isoformat(),
+        "payload": payload,
+    }
+    filename = f"backup_{now.strftime('%Y%m%d_%H%M%S')}.json"
+    headers = {"Content-Disposition": f"attachment; filename=\"{filename}\""}
+    return JSONResponse(content=data, headers=headers)
+
+
+@router.post("/admin/restore")
+def restore(
+    data: Dict[str, Any] = Body(...),
+    wipe: bool = True,
+    user: Dict[str, Any] = Depends(_admin_user),
+):
+    if data.get("version") != 1 or not isinstance(data.get("payload"), dict):
+        raise HTTPException(status_code=422, detail="invalid backup")
+    payload = data["payload"]
+    required = ["users", "tokens", "missions", "assignments"]
+    for k in required:
+        if k not in payload or not isinstance(payload.get(k), list):
+            raise HTTPException(status_code=422, detail="invalid backup")
+    if wipe:
+        db = {k: payload.get(k, []) for k in required}
+    else:
+        db = load_db()
+        for k in ["users", "missions", "assignments"]:
+            existing = db.get(k, [])
+            index = {item.get("id"): i for i, item in enumerate(existing)}
+            for item in payload.get(k, []):
+                idx = index.get(item.get("id"))
+                if idx is None:
+                    existing.append(item)
+                else:
+                    existing[idx] = item
+            db[k] = existing
+        db.setdefault("tokens", [])
+    save_db(db)
+    return {"ok": True}

--- a/backend/tests/test_admin_backup.py
+++ b/backend/tests/test_admin_backup.py
@@ -1,0 +1,128 @@
+import os, sys
+sys.path.append(os.path.join(os.path.dirname(__file__), ".."))
+from fastapi.testclient import TestClient
+from app.main import app
+from app.storage import load_db, save_db
+
+
+def _admin_token(c: TestClient) -> str:
+    c.post("/auth/register", json={"username": "admin", "password": "pw"})
+    db = load_db()
+    admin = next(u for u in db["users"] if u["username"] == "admin")
+    admin["role"] = "admin"
+    save_db(db)
+    r = c.post("/auth/token-json", json={"username": "admin", "password": "pw"})
+    return r.json()["access_token"]
+
+
+def test_backup_contains_keys_admin_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    c.post("/auth/register", json={"username": "u", "password": "p"})
+    r = c.post("/auth/token-json", json={"username": "u", "password": "p"})
+    tok = r.json()["access_token"]
+    H = {"Authorization": f"Bearer {tok}"}
+    r = c.get("/admin/backup", headers=H)
+    assert r.status_code == 403
+    tok = _admin_token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    r = c.get("/admin/backup", headers=H)
+    assert r.status_code == 200
+    assert r.headers["content-type"].startswith("application/json")
+    assert "attachment; filename=\"backup_" in r.headers.get("content-disposition", "")
+    data = r.json()
+    assert data["version"] == 1
+    assert set(data["payload"].keys()) == {"users", "tokens", "missions", "assignments"}
+
+
+def test_restore_wipe_roundtrip_ok(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _admin_token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    c.post("/auth/register", json={"username": "u1", "password": "p"})
+    c.post("/auth/register", json={"username": "u2", "password": "p"})
+    c.post("/auth/token-json", json={"username": "u1", "password": "p"})
+    c.post("/auth/token-json", json={"username": "u2", "password": "p"})
+    mission = {
+        "title": "m1",
+        "start": "2025-01-01T00:00:00Z",
+        "end": "2025-01-02T00:00:00Z",
+        "positions": [{"label": "r1", "count": 1, "skills": {}}],
+    }
+    r = c.post("/missions", json=mission, headers=H)
+    mid = r.json()["id"]
+    db = load_db()
+    uid1 = next(u["id"] for u in db["users"] if u["username"] == "u1")
+    c.post(f"/missions/{mid}/assign", json={"role_label": "r1", "user_id": uid1, "status": "invited"}, headers=H)
+    r = c.get("/admin/backup", headers=H)
+    backup = r.json()
+    counts = {k: len(backup["payload"][k]) for k in ["users", "tokens", "missions", "assignments"]}
+    c.post("/admin/reset", headers=H)
+    tok = _admin_token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    r = c.post("/admin/restore", json=backup, headers=H)
+    assert r.status_code == 200
+    db2 = load_db()
+    for k, v in counts.items():
+        assert len(db2.get(k, [])) == v
+
+
+def test_restore_merge_nowipe_upserts_without_tokens(tmp_path, monkeypatch):
+    monkeypatch.setenv("DATA_DIR", str(tmp_path))
+    c = TestClient(app)
+    tok = _admin_token(c)
+    H = {"Authorization": f"Bearer {tok}"}
+    mission = {
+        "title": "orig",
+        "start": "2025-01-01T00:00:00Z",
+        "end": "2025-01-02T00:00:00Z",
+        "positions": [{"label": "r1", "count": 1, "skills": {}}],
+    }
+    r = c.post("/missions", json=mission, headers=H)
+    mid1 = r.json()["id"]
+    db = load_db()
+    admin_id = next(u["id"] for u in db["users"] if u["username"] == "admin")
+    c.post(f"/missions/{mid1}/assign", json={"role_label": "r1", "user_id": admin_id, "status": "invited"}, headers=H)
+    orig_tokens = load_db().get("tokens", []).copy()
+    r = c.get("/admin/backup", headers=H)
+    backup = r.json()
+    backup["payload"]["users"][0]["username"] = "admin2"
+    backup["payload"]["users"].append({
+        "id": 2,
+        "username": "bob",
+        "password_hash": "x",
+        "role": "intermittent",
+        "is_active": True,
+    })
+    backup["payload"]["tokens"] = [{"token": "bad", "user_id": 2, "created_at": "2020-01-01T00:00:00Z"}]
+    backup["payload"]["missions"][0]["title"] = "changed"
+    backup["payload"]["missions"].append({
+        "id": 2,
+        "title": "m2",
+        "start": "2025-01-03T00:00:00Z",
+        "end": "2025-01-04T00:00:00Z",
+        "status": "draft",
+        "positions": [{"label": "r1", "count": 1, "skills": {}}],
+    })
+    backup["payload"]["assignments"][0]["status"] = "confirmed"
+    backup["payload"]["assignments"].append({
+        "id": 2,
+        "mission_id": 2,
+        "user_id": 2,
+        "role_label": "r1",
+        "status": "invited",
+    })
+    r = c.post("/admin/restore?wipe=false", json=backup, headers=H)
+    assert r.status_code == 200
+    db2 = load_db()
+    u1 = next(u for u in db2["users"] if u["id"] == 1)
+    assert u1["username"] == "admin2"
+    assert any(u["id"] == 2 for u in db2["users"])
+    m1 = next(m for m in db2["missions"] if m["id"] == mid1)
+    assert m1["title"] == "changed"
+    assert any(m["id"] == 2 for m in db2["missions"])
+    a1 = next(a for a in db2["assignments"] if a["id"] == 1)
+    assert a1["status"] == "confirmed"
+    assert any(a["id"] == 2 for a in db2["assignments"])
+    assert db2.get("tokens", []) == orig_tokens

--- a/scripts/backup.ps1
+++ b/scripts/backup.ps1
@@ -1,0 +1,2 @@
+$hdr=@{Authorization="Bearer $env:TOKEN"}
+Invoke-RestMethod http://localhost:8001/admin/backup -Headers $hdr -OutFile ("backup_{0:yyyyMMdd_HHmmss}.json" -f (Get-Date))

--- a/scripts/restore.ps1
+++ b/scripts/restore.ps1
@@ -1,0 +1,5 @@
+param([string]$File,[switch]$NoWipe)
+$hdr=@{Authorization="Bearer $env:TOKEN"}
+$body=Get-Content $File -Raw
+$wipe = $NoWipe.IsPresent ? "false" : "true"
+Invoke-RestMethod "http://localhost:8001/admin/restore?wipe=$wipe" -Method Post -Headers $hdr -Body $body -ContentType "application/json"


### PR DESCRIPTION
## Summary
- support JSON export/import for admin data
- add PowerShell backup/restore scripts and docs
- verify backup and restore behavior with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689f993ca7648330845b2a626a0358c6